### PR TITLE
Minor Questbook title fix

### DIFF
--- a/config/ftbquests/quests/data.snbt
+++ b/config/ftbquests/quests/data.snbt
@@ -18,6 +18,6 @@
 	}
 	pause_game: false
 	progression_mode: "linear"
-	title: "R.A.D.2 quests"
+	title: "R.A.D.3 Quests"
 	version: 13
 }


### PR DESCRIPTION
From "R.A.D.2 quests" to "R.A.D.3 Quests"